### PR TITLE
Catch failures and exceptions

### DIFF
--- a/src/core/ocplint_actions.ml
+++ b/src/core/ocplint_actions.ml
@@ -85,15 +85,12 @@ let is_cmt file = Filename.check_suffix file "cmt"
 let register_default_sempatch () =
   (* TODO: Fabrice: vérifier que le fichier existe, sinon prendre celui dans
      l'exécutable par défaut*)
-  let default_patches = [
-    "./src/analysis/plugins/sempatch.md"
-  ] in
   let
     module Default = Plugin_sempatch.SempatchPlugin.MakeLintPatch(struct
       let name = "Lint from semantic patches (default)"
       let short_name = "sempatch-lint"
       let details = "Lint from semantic patches (default)."
-      let patches = default_patches
+      let patches = Globals.default_patches
     end) in
   ()
 

--- a/src/core/ocplint_actions.ml
+++ b/src/core/ocplint_actions.ml
@@ -112,11 +112,11 @@ let scan ~filters path patches =
   let all = filter_modules (scan_project path) !!ignored_files in
 
   (* All inputs for each analyze *)
-  let mls = List.filter (fun file -> is_source file) all in
-  let mlis = List.filter (fun file -> is_interface file) all in
+  let mls = List.filter is_source all in
+  let mlis = List.filter is_interface all in
 
   let cmts =
-    let files = List.filter (fun file -> is_cmt file) all in
+    let files = List.filter is_cmt all in
     List.map (fun file -> lazy (Cmt_format.read_cmt file)) files in
 
   let asts_ml, asts_mli =

--- a/src/core/parallel_engine.ml
+++ b/src/core/parallel_engine.ml
@@ -52,7 +52,15 @@ let lint all mls mlis asts_ml asts_mli cmts =
                   | Input.InStruct main ->
                     begin match Lazy.force input with
                       | None -> ()
-                      | Some input ->  main input
+                      | Some input ->
+                        try
+                          main input
+                        with
+                        | Parsed_patches.PatchError err ->
+                          Printf.eprintf
+                            "Error when parsing patch file : %S\n%!" err
+                        | Failure err ->
+                          Printf.eprintf "Error with patch file: %S\n%!" err
                     end
                   | _ -> ()) runs) checks))
     asts_ml;

--- a/src/kernel/services/plugins/globals.ml
+++ b/src/kernel/services/plugins/globals.ml
@@ -23,3 +23,7 @@ module LintMap = Map.Make (String)
 module Config = Configuration.DefaultConfig
 
 let plugins = Hashtbl.create 42
+
+let default_patches = [
+  "./src/analysis/plugins/sempatch.md"
+]

--- a/src/kernel/services/plugins/globals.mli
+++ b/src/kernel/services/plugins/globals.mli
@@ -40,3 +40,5 @@ module Config : Configuration.CONFIG
     a [LintMap.t]. *)
 val plugins :
   ((module Plugin_types.PLUGIN), (Input.input list) LintMap.t) Hashtbl.t
+
+val default_patches : string list


### PR DESCRIPTION
`ocp-lint` should not fail when `ocplib-sempatch` raise an exception.
